### PR TITLE
Add SQLite + SQLAlchemy models and seed script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+
+sqlalchemy

--- a/src/app.py
+++ b/src/app.py
@@ -8,8 +8,11 @@ for extracurricular activities at Mergington High School.
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from fastapi import status
 import os
 from pathlib import Path
+
+from src.models import SessionLocal, Activity, Participant, create_tables
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -19,63 +22,30 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
-    },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
-    },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
-    },
-    "Soccer Team": {
-        "description": "Join the school soccer team and compete in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Practice and play basketball with the school team",
-        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
-    },
-    "Art Club": {
-        "description": "Explore your creativity through painting and drawing",
-        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
-    },
-    "Drama Club": {
-        "description": "Act, direct, and produce plays and performances",
-        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
-    },
-    "Math Club": {
-        "description": "Solve challenging problems and participate in math competitions",
-        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
-        "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Develop public speaking and argumentation skills",
-        "schedule": "Fridays, 4:00 PM - 5:30 PM",
-        "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
-}
+# Ensure DB tables exist on startup
+create_tables()
+
+
+def _activities_from_db():
+    """Return a dict shaped like the original in-memory `activities` object.
+
+    This keeps the API contract stable for the frontend while using the DB.
+    """
+    db = SessionLocal()
+    try:
+        result = {}
+        activities = db.query(Activity).all()
+        for a in activities:
+            participants = [p.email for p in a.participants]
+            result[a.name] = {
+                "description": a.description,
+                "schedule": a.schedule,
+                "max_participants": a.max_participants,
+                "participants": participants,
+            }
+        return result
+    finally:
+        db.close()
 
 
 @app.get("/")
@@ -85,48 +55,52 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    return _activities_from_db()
 
 
-@app.post("/activities/{activity_name}/signup")
+@app.post("/activities/{activity_name}/signup", status_code=status.HTTP_201_CREATED)
 def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    """Sign up a student for an activity (persists to DB)."""
+    db = SessionLocal()
+    try:
+        activity = db.query(Activity).filter(Activity.name == activity_name).first()
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        # Check if already signed up
+        existing = db.query(Participant).filter(Participant.activity_id == activity.id,
+                                                 Participant.email == email).first()
+        if existing:
+            raise HTTPException(status_code=400, detail="Student is already signed up")
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
+        # Check capacity if set
+        if activity.max_participants and len(activity.participants) >= activity.max_participants:
+            raise HTTPException(status_code=400, detail="Activity is full")
 
-    # Add student
-    activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
+        participant = Participant(activity_id=activity.id, email=email)
+        db.add(participant)
+        db.commit()
+        return {"message": f"Signed up {email} for {activity_name}"}
+    finally:
+        db.close()
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    """Unregister a student from an activity (persists to DB)."""
+    db = SessionLocal()
+    try:
+        activity = db.query(Activity).filter(Activity.name == activity_name).first()
+        if not activity:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        participant = db.query(Participant).filter(Participant.activity_id == activity.id,
+                                                   Participant.email == email).first()
+        if not participant:
+            raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
-
-    # Remove student
-    activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}
+        db.delete(participant)
+        db.commit()
+        return {"message": f"Unregistered {email} from {activity_name}"}
+    finally:
+        db.close()

--- a/src/create_db.py
+++ b/src/create_db.py
@@ -1,0 +1,99 @@
+"""Create the database and seed initial activities.
+
+Run this once (or whenever you want to reset the DB):
+
+    python -m src.create_db
+
+It will create the SQLite file (data.db by default) and seed activities.
+"""
+from pathlib import Path
+from src.models import create_tables, SessionLocal, Activity, Participant
+
+SEED_ACTIVITIES = {
+    "Chess Club": {
+        "description": "Learn strategies and compete in chess tournaments",
+        "schedule": "Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 12,
+        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
+    },
+    "Programming Class": {
+        "description": "Learn programming fundamentals and build software projects",
+        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+        "max_participants": 20,
+        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
+    },
+    "Gym Class": {
+        "description": "Physical education and sports activities",
+        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+        "max_participants": 30,
+        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Soccer Team": {
+        "description": "Join the school soccer team and compete in matches",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 22,
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Practice and play basketball with the school team",
+        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
+    },
+    "Art Club": {
+        "description": "Explore your creativity through painting and drawing",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 15,
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Act, direct, and produce plays and performances",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+        "max_participants": 20,
+        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
+    },
+    "Math Club": {
+        "description": "Solve challenging problems and participate in math competitions",
+        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 10,
+        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
+    },
+    "Debate Team": {
+        "description": "Develop public speaking and argumentation skills",
+        "schedule": "Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 12,
+        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    }
+}
+
+
+def seed_db():
+    create_tables()
+    db = SessionLocal()
+    try:
+        # clear existing
+        db.query(Participant).delete()
+        db.query(Activity).delete()
+        db.commit()
+
+        for name, data in SEED_ACTIVITIES.items():
+            activity = Activity(
+                name=name,
+                description=data.get("description"),
+                schedule=data.get("schedule"),
+                max_participants=data.get("max_participants"),
+            )
+            db.add(activity)
+            db.flush()  # populate activity.id
+
+            for email in data.get("participants", []):
+                db.add(Participant(activity_id=activity.id, email=email))
+
+        db.commit()
+        print("Seeded database with initial activities.")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    seed_db()

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,38 @@
+from sqlalchemy import (create_engine, Column, Integer, String, Text,
+                        ForeignKey)
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+import os
+from pathlib import Path
+
+# Database file placed next to the repository root by default. You can override
+# with the DATABASE_URL environment variable.
+DB_PATH = Path(os.environ.get("DATABASE_FILE", Path(__file__).parent.parent / "data.db"))
+DATABASE_URL = os.environ.get("DATABASE_URL", f"sqlite:///{DB_PATH}")
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+
+class Activity(Base):
+    __tablename__ = "activities"
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(255), unique=True, nullable=False)
+    description = Column(Text, nullable=True)
+    schedule = Column(String(255), nullable=True)
+    max_participants = Column(Integer, nullable=True)
+
+    participants = relationship("Participant", back_populates="activity", cascade="all, delete-orphan")
+
+
+class Participant(Base):
+    __tablename__ = "participants"
+    id = Column(Integer, primary_key=True, index=True)
+    activity_id = Column(Integer, ForeignKey("activities.id"), nullable=False)
+    email = Column(String(255), nullable=False)
+
+    activity = relationship("Activity", back_populates="participants")
+
+
+def create_tables():
+    Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
This PR adds SQLite persistence (SQLAlchemy models), a create_db seed script, and wires the FastAPI endpoints to the DB while preserving the original API responses.

Changes:
- Add `src/models.py` with Activity and Participant models
- Add `src/create_db.py` to create and seed the DB
- Update `src/app.py` to use the DB for activities
- Add `sqlalchemy` to requirements.txt

Next steps:
- Run `python -m src.create_db` to seed the DB locally
- Add tests and optionally Alembic for migrations
